### PR TITLE
Add simple webcam application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # jingzhi
+
+This repository contains a simple camera application similar to the Photo Booth on macOS. It opens your webcam and displays the video stream.
+
+## Setup
+
+1. Install dependencies (requires Python 3):
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+Run the application with:
+```bash
+python camera_app.py
+```
+
+Press `q` to exit the application.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ python camera_app.py
 ```
 
 Press `q` to exit the application.
+
+## Browser version
+
+Open `webcam.html` in a modern browser. The page will request access to your
+camera and display the live video stream. No additional setup is required.

--- a/camera_app.py
+++ b/camera_app.py
@@ -1,0 +1,25 @@
+import cv2
+
+
+def run_camera():
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        print("Unable to open camera")
+        return
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                print("Failed to capture frame")
+                break
+            cv2.imshow('Camera', frame)
+            # Press q to exit
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                break
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    run_camera()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+opencv-python

--- a/webcam.html
+++ b/webcam.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Webcam Demo</title>
+    <style>
+        body { display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+        video { width: 80%; max-width: 600px; }
+    </style>
+</head>
+<body>
+    <video id="video" autoplay playsinline></video>
+    <script>
+        const video = document.getElementById('video');
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            navigator.mediaDevices.getUserMedia({ video: true })
+                .then(stream => {
+                    video.srcObject = stream;
+                })
+                .catch(err => {
+                    console.error('Error accessing camera:', err);
+                });
+        } else {
+            alert('getUserMedia not supported in this browser.');
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a Python webcam application similar to macOS Photo Booth
- document setup and usage instructions
- declare dependency for OpenCV

## Testing
- `python3 -m py_compile camera_app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fef7d310c833186e64e8e46722e81